### PR TITLE
Check MongoDB indexes on master node only

### DIFF
--- a/spec/tests/nosql/nosql_spec.rb
+++ b/spec/tests/nosql/nosql_spec.rb
@@ -40,8 +40,3 @@ end
 describe port(28017) do
   it { should be_listening.with('tcp') }
 end
-
-describe command("echo \"db.system.indexes.find()\" | mongo \"#{property[:server_ip]}\":27017/ceilometer") do
-    its(:stdout) { should match /"ns" : "ceilometer.resource"/ }
-end
-

--- a/spec/tests/telemetryserver/telemetryserver_spec.rb
+++ b/spec/tests/telemetryserver/telemetryserver_spec.rb
@@ -70,3 +70,10 @@ end
 describe package('ceilometer-common') do
   it { should be_installed }
 end
+
+describe command("mongo \"#{property[:server_ip]}\":27017/ceilometer " \
+                 "--eval \"assert(db.isMaster().ismaster " \
+                 "? db.system.indexes.find({ ns: 'ceilometer.resource' }).length() == 2 " \
+                 ": true)\"") do
+  it { should return_exit_status 0 }
+end


### PR DESCRIPTION
Use Javascript in Mongo shell to check for ceilometer indexes only on master node
