### PR TITLE
Retrieve hostname using an excluded tag instead of an environment variab...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,9 +12,9 @@ namespace :serverspec do
   properties.keys.each do |key|
   desc "Run serverspec to #{key}"
     RSpec::Core::RakeTask.new(key.split('.')[0].to_sym) do |t|
-      ENV['TARGET_HOST'] = key
       t.pattern = 'spec/{' + properties[key][:roles].join(',') + '}/*_spec.rb'
-#      t.rspec_opts = "-r rspec-extra-formatters -f JUnitFormatter -o serverspec-#{key}.xml"
+      t.rspec_opts = "-t ~host:#{key}"
+#      t.rspec_opts += "-r rspec-extra-formatters -f JUnitFormatter -o serverspec-#{key}.xml"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ include Serverspec::Helper::Properties
 properties = YAML.load_file('arch.yml')
 
 RSpec.configure do |c|
-    c.host  = ENV['TARGET_HOST']
+    c.host  = c.exclusion_filter()[:host]
     set_property properties[c.host]
     options = Net::SSH::Config.for(c.host)
     user = 'root'


### PR DESCRIPTION
The Rakefile used the TARGET_HOST environment variable to specify the host to check. That ceased to work in new versions of rspec.

This patch fixes this by using rspec excluded tags. It passes an "-tag ~host:os-ci-test4" argument to the rspec command line.
