### PR TITLE
cinder: test multi-backend

### DIFF
--- a/spec/tests/volumecontroller/volumecontroller_spec.rb
+++ b/spec/tests/volumecontroller/volumecontroller_spec.rb
@@ -39,6 +39,7 @@ end
 describe file('/etc/cinder/cinder.conf') do
   its(:content) { should match /^rbd_pool=volumes$/ }
   its(:content) { should match /^rbd_user=cinder$/ }
+  its(:content) { should match /^volume_backend_name=ceph$/ }
 end
 
 describe file('/etc/ceph/ceph.client.cinder.keyring') do


### PR DESCRIPTION
Test if multi-backend is actually enabled with RBD driver by default.
