### PR TITLE
Use env vars to pass host and not exclusion filters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :serverspec do
   desc "Run serverspec to #{key}"
     RSpec::Core::RakeTask.new(key.split('.')[0].to_sym) do |t|
       t.pattern = 'spec/{' + properties[key][:roles].join(',') + '}/*_spec.rb'
-      t.rspec_opts = "-t ~host:#{key}"
+      ENV['TARGET_HOST'] = key
 #      t.rspec_opts += "-r rspec-extra-formatters -f JUnitFormatter -o serverspec-#{key}.xml"
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ include Serverspec::Helper::Properties
 properties = YAML.load_file('arch.yml')
 
 RSpec.configure do |c|
-    c.host  = c.exclusion_filter()[:host]
+    c.host  = ENV['TARGET_HOST']
     set_property properties[c.host]
     options = Net::SSH::Config.for(c.host)
     user = 'root'


### PR DESCRIPTION
Exclusion filters should not be used to pass
the host name. They are an rspec feature that
is not intended to pass arbitrary information.

In my use case, where I need to specify ip
addresses as the address.

This patch updates the Rakefile and spec_helper
to pass hostnames as the TARGET_HOST env var (
which matches the multi-host example from
http://serverspec.org/advanced_tips.html