### PR TITLE
install: Add a set of tests for the install profiles

### DIFF
--- a/spec/puppetdb_server/puppetdb_server_spec.rb
+++ b/spec/puppetdb_server/puppetdb_server_spec.rb
@@ -1,0 +1,1 @@
+require_relative '../tests/install/puppetdb_server_spec.rb'

--- a/spec/puppetmaster/puppetmaster_spec.rb
+++ b/spec/puppetmaster/puppetmaster_spec.rb
@@ -1,0 +1,1 @@
+require_relative '../tests/install/puppetmaster_spec.rb'

--- a/spec/tests/install/puppetdb_server_spec.rb
+++ b/spec/tests/install/puppetdb_server_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+#
+# cloud::install::puppetdb_server
+#
+
+describe port(8081) do
+  it { should be_listening.with('tcp') }
+end

--- a/spec/tests/install/puppetmaster_spec.rb
+++ b/spec/tests/install/puppetmaster_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+#
+# cloud::install::puppetmaster
+#
+
+describe port(8140) do
+  it { should be_listening.with('tcp') }
+end


### PR DESCRIPTION
Add tests for the puppetmaster and the puppetdb_server profiles.
It checks respectively port 8140 (puppetmaster) and 8081 (puppetdb).
