### PR TITLE
puppetdb,pupptemaster: use tcp6 for port checking

### DIFF
--- a/spec/tests/install/puppet_master_spec.rb
+++ b/spec/tests/install/puppet_master_spec.rb
@@ -5,5 +5,5 @@ require 'spec_helper'
 #
 
 describe port(8140) do
-  it { should be_listening.with('tcp') }
+  it { should be_listening.with('tcp6') }
 end

--- a/spec/tests/install/puppetdb_spec.rb
+++ b/spec/tests/install/puppetdb_spec.rb
@@ -5,5 +5,5 @@ require 'spec_helper'
 #
 
 describe port(8081) do
-  it { should be_listening.with('tcp') }
+  it { should be_listening.with('tcp6') }
 end


### PR DESCRIPTION
Use tcp6 instead of tcp for port checking since it listens with tcp6 status

```
root@server:/var/lib/jenkins# netstat -tlnp | grep -e '8081' -e '8140'
tcp6       0      0 :::8140                 :::*                    LISTEN      4524/apache2    
tcp6       0      0 10.151.68.48:8081       :::*                    LISTEN      5529/java       
```
