### PR TITLE
/etc/logrotate.d/haproxy can be 644 or 444

### DIFF
--- a/spec/tests/lb/lb_spec.rb
+++ b/spec/tests/lb/lb_spec.rb
@@ -49,7 +49,12 @@ describe file('/etc/logrotate.d/haproxy') do
   its(:content) { should match /delaycompress/ }
   its(:content) { should match /compress/ }
 
-  it { should be_mode 444 }
+  it { should_not be_executable }
+  it { should be_readable.by('owner') }
+  it { should be_readable.by('group') }
+  it { should be_readable.by('others') }
+  it { should_not be_writable.by('group') }
+  it { should_not be_writable.by('others') }
   it { should be_owned_by 'root' }
 end
 


### PR DESCRIPTION
relax the /etc/logrotate.d/haproxy privilege check to accept either
444 or 644. 644 is a perfectly valide mode and was the standard before
the recent 5bb0b04d68f3031681058090721bd99a5adaae35 commit.

(cherry picked from commit a494e557f88286ea539eab88bd4e61a57b3b45b6)