### PR TITLE
telemetryserver: Remove syslog pattern test

### DIFF
--- a/spec/tests/telemetryserver/telemetryserver_spec.rb
+++ b/spec/tests/telemetryserver/telemetryserver_spec.rb
@@ -32,8 +32,6 @@ describe file('/etc/ceilometer/ceilometer.conf') do
   it { should be_grouped_into 'ceilometer' }
   its(:content) { should match /^rpc_backend=ceilometer.openstack.common.rpc.impl_kombu$/ }
   its(:content) { should match /^notification_topics=notifications$/ }
-  its(:content) { should match /^use_syslog=True$/ }
-  its(:content) { should match /^syslog_log_facility=LOG_LOCAL0$/ }
 end
 
 describe command("ceilometer --os-username #{property[:ks_user_name]} --os-password #{property[:ks_user_password]} --os-tenant-name #{property[:ks_tenant_name]} --os-auth-url #{property[:endpoint_protocol]}://#{property[:vip_public]}:5000/v2.0 meter-list") do


### PR DESCRIPTION
Currently serverspec always wants to have 'use_syslog=True' in ceilometer.conf
even if we set the option to False in env yaml file.

https://github.com/enovance/openstack-yaml-infra/blob/master/data/common.yaml.tmpl#L64

This patch removes the pattern check on syslog.

Signed-off-by: Dimitri Savineau <dimitri.savineau@enovance.com>
(cherry picked from commit 9acf33f0d3af57500c3e1144eeccfbb49f9fa5cb)